### PR TITLE
This commit fixes a `NameError` that occurred in the `_sanitize_srt_c…

### DIFF
--- a/api_handler.py
+++ b/api_handler.py
@@ -88,7 +88,7 @@ def get_storyboard_from_srt(srt_content: str, api_key: str, film_duration: int, 
         system_prompt = system_prompt.replace("{durasi_film}", str(film_duration // 60)).replace("{lang}", language)
 
         # Sanitize SRT content to reduce potential safety triggers
-        sanitized_srt = _sanitize_srt_content(srt_content)
+        sanitized_srt = _sanitize_srt_content(srt_content, log)
 
         prompt_parts = [
             system_prompt,
@@ -211,7 +211,7 @@ def get_storyboard_from_srt(srt_content: str, api_key: str, film_duration: int, 
         log(traceback.format_exc())
         return None
 
-def _sanitize_srt_content(srt_content: str) -> str:
+def _sanitize_srt_content(srt_content: str, log) -> str:
     """
     Sanitizes SRT content to reduce potential safety triggers while preserving meaning.
     """


### PR DESCRIPTION
…ontent` helper function within `api_handler.py`.

The helper function was attempting to call the `log` function, which was defined in the parent function's scope but was not accessible. This has been resolved by passing the `log` function as a parameter to `_sanitize_srt_content`.