### PR TITLE
This commit fixes a `NameError: name 'os' is not defined` that occurr…

### DIFF
--- a/api_handler.py
+++ b/api_handler.py
@@ -3,6 +3,7 @@
 # specifically the Google Gemini API for storyboard and speech generation.
 
 import google.generativeai as genai
+import os
 import json
 import pathlib
 import time


### PR DESCRIPTION
…ed in `api_handler.py`.

The error was caused by a call to `os.remove()` in the cleanup logic without the `os` module being imported. This commit adds the required `import os` statement at the top of the file, resolving the crash.