### PR TITLE
This commit fixes a `PermissionError: [Errno 13] Permission denied` t…

### DIFF
--- a/api_manager.py
+++ b/api_manager.py
@@ -5,8 +5,10 @@ import json
 from pathlib import Path
 
 class APIManager:
-    def __init__(self, filepath: str = 'api_keys.json'):
-        self.filepath = Path(filepath)
+    def __init__(self, filename: str = 'api_keys.json'):
+        # Store the config file in the user's home directory for cross-platform compatibility
+        # and to avoid permission errors.
+        self.filepath = Path.home() / filename
         self.keys = []
         self.load_keys()
 


### PR DESCRIPTION
…hat occurred when trying to save the `api_keys.json` file.

The application was attempting to write the file in its installation directory, which often has restricted write permissions. The fix modifies `api_manager.py` to save `api_keys.json` in the user's home directory (`Path.home()`), which is the standard, cross-platform location for user-specific configuration files and avoids permission issues.